### PR TITLE
SOV-59: Moved the socket.io setting back into the document.ready

### DIFF
--- a/Client/Public/Controllers/GameController.js
+++ b/Client/Public/Controllers/GameController.js
@@ -11,6 +11,9 @@ var is_host = true;
 var is_in_a_server = false;
 
 $(document).ready(function() {
+    // Setup socket - connection to server (Do not move this from the document ready)
+    socket = io('https://sovereign-nathansteward.c9users.io');
+
     initModels();
     populateTitleList();
     
@@ -27,8 +30,6 @@ $(document).ready(function() {
 
 // Initializes models with content.
 function initModels() {
-    // Setup socket - connection to server
-    socket = io('https://sovereign-nathansteward.c9users.io');
     // Init all resource values to 0.
     modelResource['resource'] = 0;
     modelResource['townspeopleAvailable'] = 0;


### PR DESCRIPTION
#59 
* Fixed the issue where disconnecting from a room would disallow you from rejoining it.

`"This was probably because I moved it into the initModels() call, which is called multiple times (each time you leave a room, for example, disconnecting it from the original socket)."`