### PR TITLE
SOV-61: Chat scrollbar now stays at bottom, where new messages come in, if they are not actively scrolled away from the bottom

### DIFF
--- a/Client/Public/CSS/default.css
+++ b/Client/Public/CSS/default.css
@@ -276,6 +276,8 @@ body, html {
     height: calc(100% - 22px);
     width: 100%;
     color: black;
+    display: flex;
+    flex-direction: column-reverse;
     overflow-y: auto;
     padding: 0px 5px;
     word-wrap: break-word;

--- a/Client/Public/Controllers/GameController.js
+++ b/Client/Public/Controllers/GameController.js
@@ -541,9 +541,7 @@ function getUsersInCurrentRoom() {
 // certain messages from the server.
 function setupServerEmitListeners() {
     socket.on('chat_message_from_server', function(message) {
-        if (message != '') {
-            createChatMessage(message);
-        }
+        createChatMessage(message);
     });
     
     socket.on('new_player_joined_game', function(player_name) {

--- a/Client/Public/Controllers/GameController.js
+++ b/Client/Public/Controllers/GameController.js
@@ -178,10 +178,10 @@ function printIntroductoryMessage() {
 
 // Output text to the flavor text area.
 function outputToFlavorTextArea(text) {
-    var flavorTextArea = document.getElementById('flavorTextArea');
     if (is_host && is_in_a_server) {
         socket.emit('host_broadcast_output_to_flavor_text_area', text);
     }
+    var flavorTextArea = document.getElementById('flavorTextArea');
     var message = document.createElement('div');
     message.classList = 'flavor-text-area-message';
     var messageContent = document.createElement('p');
@@ -355,14 +355,26 @@ function generateResource() {
 
 // Creates a message in the chat box.
 function createChatMessage(message) {
-    var chatboxTextDisplay = document.getElementById('chatboxTextDisplay');
-    var chatMessage = document.createElement('p');
-    if (message.username && message.message) {
-        chatMessage.innerText = message.username + ': ' + message.message;
-    } else {
-        chatMessage.innerText = message;
+    if (checkChatMessagePresence(message)) {
+        var chatboxTextDisplay = document.getElementById('chatboxTextDisplay');
+        var chatMessage = document.createElement('p');
+        if (message.username && message.message) {
+            chatMessage.innerText = message.username + ': ' + message.message;
+        } else {
+            chatMessage.innerText = message;
+        }
+        $(chatboxTextDisplay).prepend(chatMessage);
     }
-    chatboxTextDisplay.appendChild(chatMessage);
+}
+
+// Checks that a chat message is not empty
+function checkChatMessagePresence(message) {
+    if (typeof message === 'object' && $.trim(message.message) !== '') {
+        return true;
+    } else if (typeof message === 'string' && $.trim(message) !== '') {
+        return true;
+    }
+    return false;
 }
 
 // Joins a game room after the user has entered in a password and submitted it.
@@ -529,7 +541,9 @@ function getUsersInCurrentRoom() {
 // certain messages from the server.
 function setupServerEmitListeners() {
     socket.on('chat_message_from_server', function(message) {
-        createChatMessage(message);
+        if (message != '') {
+            createChatMessage(message);
+        }
     });
     
     socket.on('new_player_joined_game', function(player_name) {


### PR DESCRIPTION
#61 
* Chat scrollbar will now show new messages even if they are 'overflowing' from the original box, since the scrollbar will now scroll down with the new message.
* Formatted the flavor text area function slightly better.
* Created new method checkChatMessagePresence(message) which will take a message and check if, when trimmed, it does not equal ''. In other words, check for the presence of a message.