### PR TITLE
SOV-62: Added highlight to new flavor text area messages

### DIFF
--- a/Client/Public/CSS/default.css
+++ b/Client/Public/CSS/default.css
@@ -95,6 +95,10 @@ body, html {
     display: none;
 }
 
+.flavor-text-area-message-new {
+    background-color: #A17979;
+}
+
 .flavor-text-area-message-border-bottom {
     width: 55%;
     border-bottom: 1.5px solid #705858;

--- a/Client/Public/Controllers/GameController.js
+++ b/Client/Public/Controllers/GameController.js
@@ -186,6 +186,15 @@ function outputToFlavorTextArea(text) {
     message.classList = 'flavor-text-area-message';
     var messageContent = document.createElement('p');
     messageContent.innerText = text;
+    
+    // Adds highlighting to new message; removed when user hovers over it.
+    // User can enable/disable this feature in options in a future update.
+    $(messageContent).addClass('flavor-text-area-message-new');
+    messageContent.addEventListener('mouseover', function removeHighlight() {
+        $(messageContent).removeClass('flavor-text-area-message-new');
+        messageContent.removeEventListener('mouseover', removeHighlight);
+    });
+    
     var messageBorderBottom = document.createElement('div');
     messageBorderBottom.classList = 'flavor-text-area-message-border-bottom';
     message.appendChild(messageContent);


### PR DESCRIPTION
#62 
* Added new style for a slightly brighter background; this is used as a highlight for new messages unseen by the user.
* This style is added to new messages, and is removed when the user hovers over them. It shouldn't be too much of a hassle for users since it is such an indistinct difference, so they should be able to ignore it if they want to. In a future update, I plan to add an options menu which will prevent highlighting from occurring.